### PR TITLE
wrap text-only content in <pre>

### DIFF
--- a/components/publication/pdf-viewer.js
+++ b/components/publication/pdf-viewer.js
@@ -114,7 +114,7 @@ class PDFViewer extends React.Component {
             {contentList.map((content, pageno) => (
               <div key={pageno}>
                 <PageNumber numPage={pageno + 1} />
-                {content}
+                <pre>{content}</pre>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Improve the display of the text-only view ("als Text") by wrapping it in
`<pre>`:
- The line breaks are displayed
- When users copy the text it includes the line breaks
- Tables are recognisable (cf. https://offenegesetze.de/veroeffentlichung/bgbl1/2020/1#page=5)
- Instances where the text extraction put two columns of text next to
each other instead of below each other are more readable (cf. https://offenegesetze.de/veroeffentlichung/bgbl1/2020/1#page=2)

### Tables
Before:  
![image](https://user-images.githubusercontent.com/3027817/94422151-ebe79400-0186-11eb-8c05-1de6e0046f8f.png)
After:  
![image](https://user-images.githubusercontent.com/3027817/94422127-e25e2c00-0186-11eb-8bd4-5f364a49266f.png)


### Columns
Before:  
![image](https://user-images.githubusercontent.com/3027817/94422262-1df8f600-0187-11eb-8232-5af82398046b.png)
After:  
![image](https://user-images.githubusercontent.com/3027817/94422232-120d3400-0187-11eb-8839-aa3f31d90ba4.png)
